### PR TITLE
NetworkDelay2 を変更して時間切れを防止 & ビルドをネイティブ CPU 向けに最適化

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -63,11 +63,14 @@ YANEURAOU_EDITION = YANEURAOU_ENGINE_NNUE_HALFKP_1024X2_8_96
 # 1. IntelMacでSSE4.2までしか対応していないなら、APPLESSE42 を指定。AVX2に対応しているなら APPLEAVX2を指定する。
 # 2. M1以降のCPUであれば、APPLEM1を指定する。(M2でもM3でもAPPLEM1を指定する。)
 
+# ビルドするマシン向けに最適化する
+TARGET_CPU = NATIVE
+
 # --- Intel/AMD系 (x86/x64 Platform)
 #TARGET_CPU = AVX512VNNI
 #TARGET_CPU = AVX512
 #TARGET_CPU = AVXVNNI
-TARGET_CPU = AVX2
+#TARGET_CPU = AVX2
 #TARGET_CPU = SSE42
 #TARGET_CPU = SSE41
 #TARGET_CPU = SSSE3
@@ -629,6 +632,38 @@ else ifeq ($(TARGET_CPU),WASM)
 else ifeq ($(TARGET_CPU),OTHER)
 	CPPFLAGS += -DNO_SSE
 
+else ifeq ($(TARGET_CPU),NATIVE)
+	CPPFLAGS += -march=native -mtune=native
+
+	ARCH_DEFINES = $(shell echo | $(CXX) -march=native -E -dM -)
+
+	ifneq ($(findstring __znver1__, $(ARCH_DEFINES)),)
+		CPPFLAGS += -DUSE_AVX2 -mno-bmi2
+	else ifneq ($(findstring __znver2__, $(ARCH_DEFINES)),)
+		CPPFLAGS += -DUSE_AVX2 -mno-bmi2
+	else ifneq ($(findstring __znver3__, $(ARCH_DEFINES)),)
+		CPPFLAGS += -DUSE_AVX2 -DUSE_BMI2
+	else ifneq ($(findstring __AVX512F__, $(ARCH_DEFINES)),)
+		ifneq ($(findstring __AVX512VNNI__, $(ARCH_DEFINES)),)
+			CPPFLAGS += -DUSE_AVX512 -DUSE_BMI2 -DUSE_VNNI
+		else
+			CPPFLAGS += -DUSE_AVX512 -DUSE_BMI2
+		endif
+	else ifneq ($(findstring __AVX2__, $(ARCH_DEFINES)),)
+		ifneq ($(findstring __VNNI__, $(ARCH_DEFINES)),)
+			CPPFLAGS += -DUSE_AVX2 -DUSE_BMI2 -DUSE_VNNI -DUSE_AVXVNNI
+		else
+			CPPFLAGS += -DUSE_AVX2 -DUSE_BMI2
+		endif
+	else ifneq ($(findstring __SSE4_2__, $(ARCH_DEFINES)),)
+		CPPFLAGS += -DUSE_SSE42
+	else ifneq ($(findstring __SSE4_1__, $(ARCH_DEFINES)),)
+		CPPFLAGS += -DUSE_SSE41
+	else ifneq ($(findstring __SSSE3__, $(ARCH_DEFINES)),)
+		CPPFLAGS += -DUSE_SSSE3
+	else ifneq ($(findstring __SSE2__, $(ARCH_DEFINES)),)
+		CPPFLAGS += -DUSE_SSE2
+	endif
 endif
 
 # YANEURAOU_EDITION , CPUターゲット名 などのシンボルをコンパイル時に定義してやる。

--- a/source/timeman.cpp
+++ b/source/timeman.cpp
@@ -41,7 +41,7 @@ void TimeManagement::add_options(OptionsMap& options) {
     // ネットワークの最大遅延時間[ms]
     // 切れ負けの瞬間だけはこの時間だけ早めに指す。
     // 1.2秒ほど早く指さないとfloodgateで切れ負けしかねない。
-    options.add("NetworkDelay2", Option(0, 0, 10000));
+    options.add("NetworkDelay2", Option(100, 0, 10000));
 
     // 最小思考時間[ms]
     options.add("MinimumThinkingTime", Option(0, 0, 100000));
@@ -145,8 +145,6 @@ void TimeManagement::init_(const Search::LimitsType& limits,
 	// byoyomiとincの指定は残り時間にこの時点で加算して考える。
     remain_time =
       limits.time[us] + limits.byoyomi[us] + limits.inc[us] - (TimePoint) options["NetworkDelay2"];
-	// ここを0にすると時間切れのあと自爆するのでとりあえず100はあることにしておく。
-    remain_time = std::max(remain_time, (TimePoint) 100);
 
 	// 最小思考時間
     minimum_thinking_time = (TimePoint) options["MinimumThinkingTime"];


### PR DESCRIPTION
NetworkDelay2 が 50ms だと時間切れが発生することを確認しました。100ms であれば発生しないようです。

ビルドをネイティブ CPU 向けに最適化したことで、手元の環境（Ryzen 9 9950X）では約 10% の速度向上が見られました。