### PR TITLE
Remove nmp verification search

### DIFF
--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -655,7 +655,6 @@ void Search::YaneuraOuWorker::pre_start_searching() {
 
     // 📝 StockfishではThreadPool::start_thinking()で行っているが、
     //     やねうら王では、派生classのpre_start_thinking()以降で行う。
-    nmpMinPly       = 0;
     bestMoveChanges = 0;
     rootDepth = completedDepth = 0;
 
@@ -2869,7 +2868,7 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
     // 💡 盤上にpawn以外の駒がある ≒ pawnだけの終盤ではない。
     // 🤔 将棋でもこれに相当する条件が必要かも。
 #endif
-        && ss->ply >= nmpMinPly && !is_loss(beta)
+        && !is_loss(beta)
         // 同じ手番側に連続してnull moveを適用しない
     )
     {
@@ -2897,38 +2896,8 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
 
         undo_null_move(pos);
 
-        // Do not return unproven mate or TB scores
-        // 証明されていないmate scoreやTB scoreはreturnで返さない。
-
         if (nullValue >= beta && !is_win(nullValue))
-        {
-            // 1手パスしてもbetaを上回りそうであることがわかったので
-            // これをもう少しちゃんと検証しなおす。
-
-            if (nmpMinPly || depth < 16)
-                return nullValue;
-
-            ASSERT_LV3(!nmpMinPly);  // Recursive verification is not allowed
-                                     // 再帰的な検証は認めていない。
-
-            // Do verification search at high depths, with null move pruning disabled
-            // until ply exceeds nmpMinPly.
-            //
-            // 💡 null move枝刈りを無効化して、plyがnmpMinPlyを超えるまで
-            //     高いdepthで検証のための探索を行う。
-
-            nmpMinPly = ss->ply + 3 * (depth - R) / 4;
-
-            // 📝 nullMoveせずに(現在のnodeと同じ手番で)同じ深さで探索しなおして本当にbetaを超えるか検証する。
-            //     cutNodeにしない。
-
-            Value v = search<NonPV>(pos, ss, beta - 1, beta, depth - R, false);
-
-            nmpMinPly = 0;
-
-            if (v >= beta)
-                return nullValue;
-        }
+            return is_win(nullValue) ? beta : nullValue;
     }
 
 	// ここでimproving計算しなおす。

--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -2896,7 +2896,7 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
 
         undo_null_move(pos);
 
-        if (nullValue >= beta && !is_win(nullValue))
+        if (nullValue >= beta)
             return is_win(nullValue) ? beta : nullValue;
     }
 

--- a/source/engine/yaneuraou-engine/yaneuraou-search.h
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.h
@@ -529,7 +529,7 @@ class YaneuraOuWorker: public Worker {
 
     // selDepth : 選択探索の深さ。
     // 💡depthとPV lineに対するUSI infoで出力するselDepth。
-    int selDepth, nmpMinPly;
+    int selDepth;
 
 	// 探索時に評価値に楽観的バイアスを与えるために用いるパラメーター。
 	Value optimism[COLOR_NB];


### PR DESCRIPTION
Null Move Pruningでのverification searchとは、チェスでZugzwangの際に誤った枝刈りが行われないようにするために存在しますが、将棋ではそのような状態は非常に稀なため、削除しました。

```
Elo   | 7.78 +- 5.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 14600 W: 7173 L: 6846 D: 581
Penta | [1576, 265, 3469, 236, 1754]
```
https://bench.kishibe.dyndns.tv/test/59/