### PR TITLE
more aggressive nmp reduction

### DIFF
--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -2877,7 +2877,7 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
         // Null move dynamic reduction based on depth
         // (残り探索)深さと評価値に基づくnull moveの動的なreduction
 
-        Depth R = 7 + depth / 3;
+        Depth R = 7 + depth / 2;
 
         ss->currentMove                   = Move::null();
         ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];


### PR DESCRIPTION
```
Elo   | 7.56 +- 5.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 15172 W: 7445 L: 7115 D: 612
Penta | [1624, 271, 3634, 265, 1792]
```
https://bench.kishibe.dyndns.tv/test/61/