### PR TITLE
skip double/triple extensions for capture moves

### DIFF
--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -3381,8 +3381,11 @@ moves_loop:  // When in check, search starts here
 
                 // 📝 2重延長を制限して探索の組合せ爆発を回避する必要がある。
 
-                extension =
-                  1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);
+                if (pos.capture(move))
+                    extension = 1;
+                else
+                    extension =
+                        1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);
 
                 depth++;
             }


### PR DESCRIPTION
Singular Extensionsでは、駒取りに対してdouble extensionsやtriple extensionsのような過度な拡張を行うと、child nodeで駒打ちが大量に発生し探索が発散する可能性があります。そのため、駒取りの場合はdouble/triple extensionsを行わないようにしました。

このアイディアの元は、CiekceさんがStoatに導入したパッチです。

```
Elo   | 23.59 +- 10.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 3938 W: 2013 L: 1746 D: 179
Penta | [379, 78, 919, 83, 510]
```
https://bench.kishibe.dyndns.tv/test/63/