### PR TITLE
simplify the triple-ext formula

### DIFF
--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -3376,8 +3376,7 @@ moves_loop:  // When in check, search starts here
                 int corrValAdj   = std::abs(correctionValue) / 299134;
                 int doubleMargin = -4 + 74 * PvNode - 181 * !ttCapture - corrValAdj
                                  - 604 * ttMoveHistory / 186657 - (ss->ply > rootDepth) * 26;
-                int tripleMargin = 61 + 587 * PvNode - 229 * !ttCapture + 134 * ss->ttPv - corrValAdj
-                                 - (ss->ply * 2 > rootDepth * 3) * 51;
+                int tripleMargin = 61 + 587 * PvNode - 229 * !ttCapture + 134 * ss->ttPv - corrValAdj;
 
                 // 📝 2重延長を制限して探索の組合せ爆発を回避する必要がある。
 


### PR DESCRIPTION
STC didn't pass, but stopped:
```
Elo   | -1.29 +- 7.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.08 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 7800 W: 3810 L: 3839 D: 151
Penta | [930, 63, 1927, 66, 914]
```
https://bench.kishibe.dyndns.tv/test/144/

Passed LTC:
```
Elo   | 7.74 +- 6.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 9742 W: 4745 L: 4528 D: 469
Penta | [1014, 195, 2342, 200, 1120]
```
https://bench.kishibe.dyndns.tv/test/143/