### PR TITLE
Simplify the futilityMult formula

### DIFF
--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -2843,7 +2843,7 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
         // 💡 depth(残り探索深さ)に応じたfutility margin。
 
 		auto futility_margin = [&](Depth d) {
-            Value futilityMult = 115 - 2 * !ss->ttHit;
+            Value futilityMult = 115;
 
             return futilityMult * d                                //
                  - 1547 * improving * futilityMult / 1024          //


### PR DESCRIPTION
Failed STC:
```
Elo   | -6.25 +- 5.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.36 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 13122 W: 6304 L: 6540 D: 278
Penta | [1571, 131, 3280, 121, 1458]
```
https://bench.kishibe.dyndns.tv/test/181/

Passed LTC:
```
Elo   | 1.95 +- 3.77 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.01 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 30000 W: 14405 L: 14237 D: 1358
Penta | [3262, 588, 7205, 610, 3335]
```
https://bench.kishibe.dyndns.tv/test/183/